### PR TITLE
Update hickory to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ categories = ["network-programming", "data-structures"]
 license = "MIT"
 
 [dependencies]
-trust-dns-proto = { version = "0.22.0", features = ["dnssec"] }
+hickory-proto = { version = "0.24.0", features = ["dnssec"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ impl List {
     /// [`Name`]: trust_dns_proto::rr::domain::Name
     pub fn from_trustdns_name(
         &self,
-        name: &trust_dns_proto::rr::domain::Name,
+        name: &hickory_proto::rr::domain::Name,
     ) -> io::Result<DnsName> {
         self.parse_dns_name(&name.to_ascii())
     }
@@ -420,8 +420,8 @@ mod unit_tests {
 
     #[test]
     fn trustdns() -> Result<(), std::io::Error> {
+        use hickory_proto::rr::domain::Name;
         use std::str::FromStr;
-        use trust_dns_proto::rr::domain::Name;
         let list = List::from_path("suffix-list.txt").unwrap();
 
         let domain = list.from_trustdns_name(&Name::from_str("a.b.c").unwrap())?;


### PR DESCRIPTION
Update trust-dns dependency to new name hickory and latest version 0.24