### PR TITLE
upgrade hickory-proto, bump crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dns_name"
 authors = ["BlueCat Networks <support@bluecatnetworks.com>"]
 description = "DNS name parsing with public suffix lookup"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/dns_name"
@@ -21,4 +21,4 @@ categories = ["network-programming", "data-structures"]
 license = "MIT"
 
 [dependencies]
-hickory-proto = { version = "0.24.0", features = ["dnssec"] }
+hickory-proto = { version = "0.25.1", features = ["dnssec-ring"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dns_name"
 authors = ["BlueCat Networks <support@bluecatnetworks.com>"]
 description = "DNS name parsing with public suffix lookup"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 # These URLs point to more information about the repository
 documentation = "https://docs.rs/dns_name"


### PR DESCRIPTION
Upgrading the hickory-proto crate so that projects depending on this one can upgrade.

The `dnssec` feature flag was no longer available and the [hickory-dns README](https://github.com/hickory-dns/hickory-dns?tab=readme-ov-file#dnssec-status) recommends using the dnssec-ring flag to enable dnssec: 